### PR TITLE
make use of telegraf_agent_config_path var

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -12,23 +12,23 @@
     group: telegraf
     state: present
     create_home: False
-    home: /etc/telegraf
+    home: "{{ telegraf_agent_config_path }}"
     uid: "{{ telegraf_uid_docker }}"
     system: True
   become: yes
 
-- name: Create /etc/telegraf (home) directory
+- name: Create Telegraf agent (home) directory
   file:
-    path: /etc/telegraf
+    path: "{{ telegraf_agent_config_path }}"
     owner: telegraf
     group: telegraf
     mode: 0750
     state: directory
   become: yes
 
-- name: Create /etc/telegraf.d directory
+- name: Create telegraf.d directory
   file:
-    path: /etc/telegraf/telegraf.d
+    path: "{{ telegraf_agent_config_path }}/telegraf.d"
     owner: telegraf
     group: telegraf
     mode: 0750
@@ -51,7 +51,7 @@
     security_opts:
       - apparmor:unconfined
     volumes:
-      - /etc/telegraf:/etc/telegraf:ro
+      - "{{ telegraf_agent_config_path }}:/etc/telegraf:ro"
       - /:/hostfs:ro
       - /etc:/hostfs/etc:ro
       - /proc:/hostfs/proc:ro


### PR DESCRIPTION
**Fixes an issue**
telegraf_agent_config_path variable was not used everywhere in the docker.yml.
