### PR TITLE
remove uid and gid for docker user

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ These properties set in how and what package will be installed.
 * `telegraf_agent_docker_network_mode`: Networking mode of the docker container. Default: `bridge`
 * `telegraf_agent_docker_restart_policy`: Docker container restart policy. Default: `unless-stopped`
 * `telegraf_agent_docker_image_version`: The version of the Docker Telegraf image to be used. Default the value contains the value given for `telegraf_agent_version`. Can be set to `latest` to get the actual `latest` tag for the provided Docker image.
-* `telegraf_uid_docker`: Override user id. Default: `995`
-* `telegraf_gid_docker`: Override group id. Default: `998`
 * `telegraf_agent_docker_registry`: Define a custom docker registry. Default: `""`
 * `telegraf_agent_docker_network`: attach to custom docker network. Default: `bridge`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,8 +22,6 @@ telegraf_agent_config_path: /etc/telegraf
 telegraf_win_logfile_rotation_max_archives: 3
 
 # Docker specific settings
-telegraf_uid_docker: 998
-telegraf_gid_docker: 995
 telegraf_agent_docker: False
 telegraf_agent_docker_name: telegraf
 telegraf_agent_docker_network_mode: bridge

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 telegraf_enabled: True
 # defaults file for ansible-telegraf
 
-telegraf_agent_version: 1.18.2
+telegraf_agent_version: 1.26.0
 telegraf_agent_version_patch: 1
 telegraf_agent_package: telegraf
 telegraf_agent_package_file_deb: telegraf_{{ telegraf_agent_version }}-{{ telegraf_agent_version_patch }}_{{ telegraf_agent_package_arch }}.deb

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -4,7 +4,6 @@
   group:
     name: telegraf
     state: present
-    gid: "{{ telegraf_gid_docker }}"
 
 - name: Adding Telegraf user
   user:
@@ -13,7 +12,6 @@
     state: present
     create_home: False
     home: "{{ telegraf_agent_config_path }}"
-    uid: "{{ telegraf_uid_docker }}"
     system: True
   become: yes
 
@@ -37,7 +35,7 @@
 
 - name: Ensure Telegraf Docker container is running
   docker_container:
-    user: "{{ telegraf_uid_docker }}:{{ telegraf_gid_docker }}"
+    user: "telegraf:telegraf"
     name: "{{ telegraf_agent_docker_name }}"
     image: "{{ telegraf_agent_docker_registry }}telegraf:{{ telegraf_agent_docker_image_version }}"
     state: started

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -11,7 +11,6 @@
     group: telegraf
     state: present
     create_home: False
-    home: "{{ telegraf_agent_config_path }}"
     system: True
   become: yes
 


### PR DESCRIPTION
**Description of PR**
Removes the fixed uid(998) and gid(995) from telegraf user which leads to problems with already used ids.

**Type of change**
Bugfix Pull Request

